### PR TITLE
Limit elasticsearch to an older version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ blist>=1.3.6
 boto3>=1.4.4
 configparser>=3.5.0
 croniter==1.3.8
-elasticsearch
+elasticsearch<6.0.0
 envparse>=0.2.0
 exotel>=0.1.3
 jira>=1.0.10


### PR DESCRIPTION
We are not supporting ES 6.0 or higher so we are limiting the client package